### PR TITLE
Fix folder icon

### DIFF
--- a/scalable/places/inode-directory.svg
+++ b/scalable/places/inode-directory.svg
@@ -1,0 +1,1 @@
+folder.svg


### PR DESCRIPTION
Resolves issues #10 and #9.

Some desktop environments are not using the correct folder icon. This is because there is no `inode-directory.svg` icon present in [scalable/places](https://github.com/m4thewz/dracula-icons/tree/main/scalable). The desktop environment falls back to the next available icon, which is the fixed size (16/22/24) version that has the alternate symbolic design.

This is fixed by making a symlink in [scalable/places](https://github.com/m4thewz/dracula-icons/tree/main/scalable): `inode-directory.svg -> folder.svg`
___
Thanks for adapting these icons to the Dracula color scheme. They look great!